### PR TITLE
feat(tof): add support for VL6180X and APDS9960 sensors with OLED dis…

### DIFF
--- a/ProtoESP-Controller/TOF_README.md
+++ b/ProtoESP-Controller/TOF_README.md
@@ -1,0 +1,43 @@
+# Time-of-Flight (TOF) Sensor Support
+
+This project now supports two additional proximity sensors alongside the existing IR sensor:
+
+## Supported TOF Sensors
+
+### 1. Adafruit VL6180X (Time-of-Flight Distance Sensor)
+- **Measures:** Distance in millimeters (mm)
+- **Wiring (I2C):**
+  - SDA: ESP32 SDA (default GPIO 8)
+  - SCL: ESP32 SCL (default GPIO 9)
+  - VIN: 3.3V or 5V
+  - GND: GND
+
+### 2. SparkFun APDS9960 (Proximity/Color/Gesture Sensor)
+- **Measures:** Proximity value (0-255)
+- **Wiring (I2C):**
+  - SDA: ESP32 SDA (default GPIO 8)
+  - SCL: ESP32 SCL (default GPIO 9)
+  - VIN: 3.3V
+  - GND: GND
+
+## Configuration
+- No changes to existing IR sensor logic. All sensors work in parallel.
+- Libraries are automatically installed via PlatformIO:
+  - `Adafruit VL6180X`
+  - `SparkFun APDS9960`
+
+## Usage
+- Sensor values are displayed on the OLED (if enabled) and logged to Serial every second.
+- Initialization errors are reported to Serial.
+
+## Manual Testing
+- Check Serial Monitor for `[TOF] VL6180X Distance: ...` and `[TOF] APDS9960 Proximity: ...` messages.
+- On OLED, look for a line like `VL:xxxmm AP:yyy` (where xxx is distance in mm, yyy is proximity value).
+- If values are not updating, check wiring and I2C addresses.
+
+## Schematic
+See `controller-diagram.png` for I2C wiring reference.
+
+---
+
+*For more details, see the main README.*

--- a/ProtoESP-Controller/platformio.ini
+++ b/ProtoESP-Controller/platformio.ini
@@ -1,6 +1,6 @@
 [env:esp32-s3]
 board = esp32-s3-devkitc1-n16r8 ;Depending on your board, change the "n16r8" to your board! Example: esp32-s3-devkitc1-n8r2
-board_build.variant = esp32_s3r8n16 ;rmt conflict fix, "esp32s3" variant imports soc_caps.h at that does some RMT define things... 
+board_build.variant = esp32_s3r8n16 ;rmt conflict fix, "esp32s3" variant imports soc_caps.h at that does some RMT define things...
 platform = https://github.com/pioarduino/platform-espressif32.git#develop
 framework = arduino
 board_build.filesystem = littlefs
@@ -9,11 +9,11 @@ monitor_speed = 115200
 monitor_filters = esp32_exception_decoder, time
 board_build.partitions = 8MB_20-20-40.csv ;If your ESP has 4MB of Flash, change this to "4MB_17-17-05.csv"
 extra_scripts = genCRC-auto.py
-build_flags = 
+build_flags =
 	-DARDUINO_USB_CDC_ON_BOOT=0
 ;	-DCORE_DEBUG_LEVEL=5
 	-DELEGANTOTA_USE_ASYNC_WEBSERVER=1
-lib_deps = 
+lib_deps =
 	bblanchon/StreamUtils@1.9.0
 	fastled/FastLED@3.7.8
 ;	fastled/FastLED@^3.9.14
@@ -28,4 +28,6 @@ lib_deps =
 	arduinogetstarted/ezButton@1.0.6
 	ESP32Async/AsyncTCP@3.3.8
 	ESP32Async/ESPAsyncWebServer@3.7.4
+	adafruit/Adafruit VL6180X@1.0.6
+	sparkfun/SparkFun APDS9960@1.6.2
 	ayushsharma82/ElegantOTA@3.1.7

--- a/ProtoESP-Controller/readme.md
+++ b/ProtoESP-Controller/readme.md
@@ -2,7 +2,10 @@
 ### The working brain of your Protogen!
 ![IMG_20230228_191415](https://github.com/user-attachments/assets/cc3951e1-8a25-4073-93dd-ec07dff64e9a)
 ### Main features
-- TBD
+- IR proximity sensor (default)
+- **NEW:** Time-of-Flight (TOF) sensors support:
+  - Adafruit VL6180X (distance, I2C)
+  - SparkFun APDS9960 (proximity, I2C)
 ## How to
 ### Build
 - **Connect matrices in following order** (start at the right eye when your head is in the helmet)
@@ -23,6 +26,21 @@
   - Change `blushPresent` if you're or not using blush LEDs (set `useRGBblush` to true if they are RGB and not GRB, for ear and visor color: `setup():FastLED.addLeds...`)
   - Change `INApresent` if you have or not INA219 connected
   - Change `boopMode` to what you use as boop sensor (`IR-KY` for KY032/active LOW or `Capac` for capacitive/active HIGH)
+  - **TOF sensors (VL6180X, APDS9960) are supported out-of-the-box.**
+## TOF Sensors Wiring
+
+- **VL6180X:**
+  - SDA: ESP32 SDA (default GPIO 8)
+  - SCL: ESP32 SCL (default GPIO 9)
+  - VIN: 3.3V or 5V
+  - GND: GND
+- **APDS9960:**
+  - SDA: ESP32 SDA (default GPIO 8)
+  - SCL: ESP32 SCL (default GPIO 9)
+  - VIN: 3.3V
+  - GND: GND
+
+See also: `controller-diagram.png` and `TOF_README.md` for more info.
 - In `platformio.ini`:
   - If using different capacity than n16r8, change to proper sized board (line 2)
   - If your board has lower flash capacity than 8MB, change partition file (line 11)
@@ -65,12 +83,12 @@ monitor_speed = 115200
 monitor_filters = esp32_exception_decoder
 board_build.partitions = 4MB_17-17-05.csv
 extra_scripts = genCRC-auto.py
-build_flags = 
+build_flags =
 	-DBOARD_HAS_PSRAM
 	-mfix-esp32-psram-cache-issue
 ;	-DCORE_DEBUG_LEVEL=5
 	-DELEGANTOTA_USE_ASYNC_WEBSERVER=1
-lib_deps = 
+lib_deps =
 	bblanchon/StreamUtils@1.9.0
 	fastled/FastLED@3.7.8
 	bblanchon/ArduinoJson@7.3.1

--- a/ProtoESP-Controller/src/main.cpp
+++ b/ProtoESP-Controller/src/main.cpp
@@ -83,6 +83,14 @@ LSM6DS3 myIMU;
 #include <Adafruit_INA219.h> //edited library in this sketch (replace 0.1R with 0.03R resistor on the board)
 Adafruit_INA219 ina219;
 
+// TOF Sensors
+#include "tof_vl6180.h"
+#include "tof_apds9960.h"
+int vl6180x_distance = -1;
+int apds9960_proximity = -1;
+bool vl6180x_ok = false;
+bool apds9960_ok = false;
+
 //--------------------------------//web / wifi
 #include "WiFi.h"
 #include "ESPAsyncWebServer.h"
@@ -165,7 +173,7 @@ DEFINE_GRADIENT_PALETTE( blackWhite_gp ) {
 };
 CRGBPalette16 blackWhite = blackWhite_gp;
 
-const std::vector<std::vector<int>> lookupDiag1 = 
+const std::vector<std::vector<int>> lookupDiag1 =
 {{14,15,16},
  {13,27,28,1},
  {12,26,36,17,2},
@@ -176,7 +184,7 @@ const std::vector<std::vector<int>> lookupDiag1 =
  {9,22,21,5},
  {8,7,6}};
 
-const std::vector<std::vector<int>> lookupDiag2 = 
+const std::vector<std::vector<int>> lookupDiag2 =
 {{2,3,4},
  {1,18,19,5},
  {16,17,30,20,6},
@@ -209,7 +217,7 @@ bool loadAnim(String anim, String temp) {
       error = deserializeJson(doc, bufferedFile);
       file.close();
     }
-    
+
     if(error){
       Serial.print(F("[E] Failed to deserialize animation file! : "));
       Serial.println(error.c_str());
@@ -530,7 +538,7 @@ void startWiFiWeb() {
       request->send(200, "text/plain", F("No valid parameters detected!"));
     }
   });
-  
+
   server.on("/rgb", HTTP_GET, [](AsyncWebServerRequest *request){
     if(visorType == "WS2812") {
       visorNow->type++;
@@ -662,7 +670,13 @@ void setup() {
       ina219.setCalibration_16V_8A();
     }
   }
-  
+  // Initialize VL6180X
+  vl6180x_ok = TOF_VL6180::begin();
+  // Initialize APDS9960
+  apds9960_ok = TOF_APDS9960::begin();
+  if (!vl6180x_ok) Serial.println("[E] VL6180X not found or failed to init");
+  if (!apds9960_ok) Serial.println("[E] APDS9960 not found or failed to init");
+
   while(millis()<2000) {yield();} //2s delay for the anim to load properly (idk why but it doesnt without this or with 1s)
   loadAnim("default.json","");
 
@@ -853,7 +867,7 @@ void loop() {
   }
   //Serial.println(">SPK1:"+String(micros()-looptime));
   //looptime = micros();
-  
+
   if(cfg.speechEna && laskSpeakCheck+10<=millis()) {
     finalMicAvg = 0;
     for (int i = 0; i<10; i++){
@@ -968,6 +982,29 @@ void loop() {
     }
   }
 
+  // TOF Sensor Readings
+  if (vl6180x_ok) {
+    int dist = TOF_VL6180::readDistance();
+    if (dist >= 0) {
+      vl6180x_distance = dist;
+    }
+  }
+  if (apds9960_ok) {
+    int prox = TOF_APDS9960::readProximity();
+    if (prox >= 0) {
+      apds9960_proximity = prox;
+    }
+  }
+  // Log to Serial
+  if (millis() % 1000 < 50) { // Print every ~1s
+    if (vl6180x_ok) Serial.println("[TOF] VL6180X Distance: " + String(vl6180x_distance) + " mm");
+    if (apds9960_ok) Serial.println("[TOF] APDS9960 Proximity: " + String(apds9960_proximity));
+  }
+  // OLED: show TOF values if enabled
+  if(cfg.oledEna && oledInitDone) {
+    oled.writeTOF(vl6180x_distance, apds9960_proximity);
+  }
+
   //--------------------------------//OLED routine, ~~10ms qwq~~, 1-5ms.. eh better
   if(cfg.oledEna && oledInitDone && vaStatLast+1000<millis()) {
     //looptime = micros();
@@ -1023,7 +1060,7 @@ void loop() {
               visorLeds[i] = blend(visorLeds[i], visorLedsNEW[i], (step * 255) / FADESTEPS);
             }
             ledController[0]->showLeds(cfg.bVisor); //visor
-            delay(21); 
+            delay(21);
           }
           memcpy(visorLeds, visorLedsNEW, sizeof(CRGB) * visorLedsNum);
           FdisplayVisor = false;*/

--- a/ProtoESP-Controller/src/oled.cpp
+++ b/ProtoESP-Controller/src/oled.cpp
@@ -1,3 +1,14 @@
+#include <string>
+// Show TOF sensor values (VL6180X distance in mm, APDS9960 proximity)
+void SSDOLED::writeTOF(int vl6180x_mm, int apds9960_prox) const {
+  u8g2.setDrawColor(0);
+  u8g2.drawBox(0, 48, 128, 16); // Clear bottom area
+  u8g2.setDrawColor(1);
+  u8g2.setFont(u8g2_font_t0_22b_tr);
+  String s = "VL:" + String(vl6180x_mm) + "mm AP:" + String(apds9960_prox);
+  u8g2.drawStr(0, 63, s.c_str());
+  u8g2.updateDisplayArea(0, 6, 16, 2);
+}
 #include "oled.h"
 
 U8G2_SSD1306_128X64_NONAME_F_HW_I2C u8g2(U8G2_R0,/* reset=*/ U8X8_PIN_NONE);

--- a/ProtoESP-Controller/src/oled.h
+++ b/ProtoESP-Controller/src/oled.h
@@ -69,6 +69,8 @@ public:
   void writeRGB(String) const;
   void speak(bool) const;
   void remote(bool) const;
+  // New: Show TOF sensor values
+  void writeTOF(int vl6180x_mm, int apds9960_prox) const;
 private:
   bool INAavail = false;
 };

--- a/ProtoESP-Controller/src/tof_apds9960.cpp
+++ b/ProtoESP-Controller/src/tof_apds9960.cpp
@@ -1,0 +1,27 @@
+// APDS9960 Proximity sensor implementation
+#include "tof_apds9960.h"
+#include <Wire.h>
+
+SparkFun_APDS9960 TOF_APDS9960::apds;
+
+bool TOF_APDS9960::begin() {
+    if (!apds.init()) {
+        Serial.println("[APDS9960] Failed to initialize!");
+        return false;
+    }
+    if (!apds.enableProximitySensor(false)) {
+        Serial.println("[APDS9960] Failed to enable proximity sensor!");
+        return false;
+    }
+    Serial.println("[APDS9960] Proximity sensor initialized.");
+    return true;
+}
+
+int TOF_APDS9960::readProximity() {
+    uint8_t proximity = 0;
+    if (!apds.readProximity(proximity)) {
+        Serial.println("[APDS9960] Error reading proximity!");
+        return -1;
+    }
+    return (int)proximity;
+}

--- a/ProtoESP-Controller/src/tof_apds9960.h
+++ b/ProtoESP-Controller/src/tof_apds9960.h
@@ -1,0 +1,23 @@
+// APDS9960 Proximity sensor support for ESP32
+// Author: [Your Name]
+//
+// This module provides initialization and reading functions for the SparkFun APDS9960 sensor.
+//
+// Wiring (default I2C):
+//   - SDA: connect to ESP32 SDA (default GPIO 21)
+//   - SCL: connect to ESP32 SCL (default GPIO 22)
+//   - VIN: 3.3V
+//   - GND: GND
+
+#ifndef TOF_APDS9960_H
+#define TOF_APDS9960_H
+
+#include <SparkFun_APDS9960.h>
+
+namespace TOF_APDS9960 {
+    extern SparkFun_APDS9960 apds;
+    bool begin();
+    int readProximity();
+}
+
+#endif // TOF_APDS9960_H

--- a/ProtoESP-Controller/src/tof_vl6180.cpp
+++ b/ProtoESP-Controller/src/tof_vl6180.cpp
@@ -1,0 +1,23 @@
+// VL6180X Time-of-Flight sensor implementation
+#include "tof_vl6180.h"
+#include <Wire.h>
+
+Adafruit_VL6180X TOF_VL6180::vl;
+
+bool TOF_VL6180::begin() {
+    if (!vl.begin()) {
+        Serial.println("[VL6180X] Failed to find sensor!");
+        return false;
+    }
+    Serial.println("[VL6180X] Sensor initialized.");
+    return true;
+}
+
+int TOF_VL6180::readDistance() {
+    int dist = vl.readRange();
+    if (vl.timeoutOccurred()) {
+        Serial.println("[VL6180X] Timeout occurred!");
+        return -1;
+    }
+    return dist;
+}

--- a/ProtoESP-Controller/src/tof_vl6180.h
+++ b/ProtoESP-Controller/src/tof_vl6180.h
@@ -1,0 +1,23 @@
+// VL6180X Time-of-Flight sensor support for ESP32
+// Author: [Your Name]
+//
+// This module provides initialization and reading functions for the Adafruit VL6180X sensor.
+//
+// Wiring (default I2C):
+//   - SDA: connect to ESP32 SDA (default GPIO 21)
+//   - SCL: connect to ESP32 SCL (default GPIO 22)
+//   - VIN: 3.3V or 5V
+//   - GND: GND
+
+#ifndef TOF_VL6180_H
+#define TOF_VL6180_H
+
+#include <Adafruit_VL6180X.h>
+
+namespace TOF_VL6180 {
+    extern Adafruit_VL6180X vl;
+    bool begin();
+    int readDistance();
+}
+
+#endif // TOF_VL6180_H


### PR DESCRIPTION
# Changelog – TOF Sensor Support

## 🆕 Added

1. **`platformio.ini`**
   - Added libraries:
     - `Adafruit VL6180X`
     - `SparkFun APDS9960`

2. **`src/tof_vl6180.h` / `src/tof_vl6180.cpp`**
   - New module for **VL6180X Time-of-Flight** sensor.
   - Provides initialization and distance reading functions.

3. **`src/tof_apds9960.h` / `src/tof_apds9960.cpp`**
   - New module for **APDS9960 proximity** sensor.
   - Provides initialization and proximity reading functions.

4. **`main.cpp`**
   - Included headers for VL6180X and APDS9960.
   - Added global variables for sensor readings and status.
   - `setup()`:
     - Initialized both TOF sensors with error handling/logging.
   - `loop()`:
     - Read sensor values, log to Serial, display on OLED if enabled.
   - Existing IR sensor logic left untouched.

5. **`oled.h`**
   - Extended `SSD1306OLED` class with support for TOF sensor display.

6. **`oled.cpp`**
   - Implemented `writeTOF()`:
     - Displays VL6180X and APDS9960 sensor values on the OLED screen.

7. **`README.md`**
   - Updated with:
     - Sensor support info
     - Wiring instructions
     - Usage notes

8. **`TOF_README.md`** (new)
   - Detailed documentation:
     - VL6180X and APDS9960 sensor setup
     - Wiring diagrams
     - Testing procedures

---

## ✅ Summary

- Modular support for **VL6180X** and **APDS9960** sensors (I2C).
- Existing IR sensor functionality remains unchanged.
- Sensor data available via Serial and OLED.
- Complete documentation and wiring instructions included.
